### PR TITLE
WIP generic classes

### DIFF
--- a/rasterio-stubs/_io.pyi
+++ b/rasterio-stubs/_io.pyi
@@ -1,4 +1,4 @@
-from typing import Any, BinaryIO, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, BinaryIO, Iterable, Optional, Sequence, Tuple, Union, Generic
 
 from affine import Affine
 from numpy.typing import DTypeLike, NBitBase, NDArray
@@ -23,7 +23,7 @@ def validate_resampling(resampling: Resampling) -> None: ...
 def _delete_dataset_if_exists(path: str) -> None: ...
 def in_dtype_range(value: NBitBase, dtype: DTypeLike) -> bool: ...
 
-class DatasetReaderBase(DatasetBase):
+class DatasetReaderBase(DatasetBase, Generic[NumpyDtypeT]):
     # boundless is defined here as a positional argument, but not on a subclass
     # (WarpedVRTReaderBase), which violates the Liskov substitution principle. So we add
     # a * to declare it and all later args keyword-only

--- a/test_mypy.py
+++ b/test_mypy.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+from rasterio._io import DatasetReaderBase
+import numpy as np
+
+out: DatasetReaderBase[np.float64] = DatasetReaderBase('path')
+output_array = out.read()
+reveal_type(output_array)
+# note: Revealed type is "numpy.ndarray[Any, numpy.dtype[numpy.floating*[numpy.typing._64Bit]]]"


### PR DESCRIPTION
Enables a generic typevar to propagate through the class. For example, define a reader to be of type `np.float64`, and then data read from it will also be of that type.

```py
from __future__ import annotations
from rasterio._io import DatasetReaderBase
import numpy as np

out: DatasetReaderBase[np.float64] = DatasetReaderBase('path')
output_array = out.read()
reveal_type(output_array)
# note: Revealed type is "numpy.ndarray[Any, numpy.dtype[numpy.floating*[numpy.typing._64Bit]]]"
```